### PR TITLE
UPDATES AND IMPROVEMENTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "fs-extra": "^11.1.1",
         "github-syntax-dark": "^0.5.0",
         "got": "^11.8.5",
-        "helios-core": "~2.1.0",
+        "helios-core": "~2.1.1",
         "helios-distribution-types": "^1.3.0",
         "jquery": "^3.7.1",
         "lodash.merge": "^4.6.2",
@@ -28,7 +28,7 @@
       "devDependencies": {
         "electron": "^27.1.3",
         "electron-builder": "^24.9.1",
-        "eslint": "^8.55.0"
+        "eslint": "^8.56.0"
       },
       "engines": {
         "node": "18.x.x"
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-      "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1720,15 +1720,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-      "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.55.0",
+        "@eslint/js": "8.56.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -1936,9 +1936,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2331,11 +2331,11 @@
       }
     },
     "node_modules/helios-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/helios-core/-/helios-core-2.1.0.tgz",
-      "integrity": "sha512-3RvGMJ0RDzgdZF3e0o2VtBz/NCeucDVIopz9p3GA9tjy2cl7ll8HVHSXiLG5YE1JiINU5Akacv5L6MT1g6xZuA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/helios-core/-/helios-core-2.1.1.tgz",
+      "integrity": "sha512-un9QtEofI3jR8I1aoXodJhwoQyjUvJ34/Rc8PFsvNgMyWv25F4/i4AWgRX/pZKHpy8rtyS2SwgoBSKHV1WA1DA==",
       "dependencies": {
-        "fastq": "^1.15.0",
+        "fastq": "^1.16.0",
         "fs-extra": "^11.2.0",
         "got": "^11.8.6",
         "luxon": "^3.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helioslauncher",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helioslauncher",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@electron/remote": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helioslauncher",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "productName": "Helios Launcher",
   "description": "Modded Minecraft Launcher",
   "author": "Daniel Scalzi (https://github.com/dscalzi/)",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fs-extra": "^11.1.1",
     "github-syntax-dark": "^0.5.0",
     "got": "^11.8.5",
-    "helios-core": "~2.1.0",
+    "helios-core": "~2.1.1",
     "helios-distribution-types": "^1.3.0",
     "jquery": "^3.7.1",
     "lodash.merge": "^4.6.2",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "electron": "^27.1.3",
     "electron-builder": "^24.9.1",
-    "eslint": "^8.55.0"
+    "eslint": "^8.56.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Remove mojang authserver as it has been permanently shut down.
- Upgrade Helios Launcher 2.1.1